### PR TITLE
Have node run in `production` mode.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ MAINTAINER James Swineson <jamesswineson@gmail.com>
 
 ENV ETHERPAD_VERSION 1.7.0
 
+ENV NODE_ENV production
+
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y curl unzip mysql-client supervisor gzip git python libssl-dev pkg-config build-essential && \


### PR DESCRIPTION
It gets rid of the message `app_1  | [2019-01-04 00:12:52.911] [WARN] console - Etherpad is running in Development mode.  This mode is slower for users and less secure than production mode.  You should set the NODE_ENV environment variable to production by using: export NODE_ENV=production`.
I'm not sure this matters at all.